### PR TITLE
Improve error message if SSM parameter does not exist

### DIFF
--- a/chaos_lambda.py
+++ b/chaos_lambda.py
@@ -243,7 +243,7 @@ How to use::
         return value[config_key], value.get('rate', 1)
     except InvalidParameterError as e:
         # key does not exist in SSM
-        raise InvalidParameterError("{} is not a valid SSM config".format(e))
+        raise InvalidParameterError("{} is not a valid SSM config".format(param.name))
     except KeyError as e:
         # not a valid Key in the SSM configuration
         raise KeyError(


### PR DESCRIPTION
Printing the whole `e` object is not very useful here.

It'd show something like `ssm_cache.cache.InvalidParameterError: chaoslambda.config is invalid. ['chaoslambda.config'] - {}`.

By the way, I wouldn't raise an `ssm_cache.cache.InvalidParameterError` here. Maybe it's better if we also define a proper error class in `chaos_lambda`?